### PR TITLE
fix(api): Gracefully handle non-JSON responses in API helper

### DIFF
--- a/api/upwork-api.js
+++ b/api/upwork-api.js
@@ -102,7 +102,7 @@ async function _executeGraphQLQuery(bearerToken, endpointAlias, query, variables
       );
       // Log the start of the response that failed to help debug what was received
       console.warn(`Response text that failed parsing: ${responseBodyText.substring(0, 500)}`);
-      return { error: true, type: 'parsing', message: parsingError.message };
+      return { error: true, type: 'parsing', message: parsingError.message, body: responseBodyText.substring(0, 500) };
     }
     // --- End of Recommended Change ---
   } catch (error) {

--- a/api/upwork-api.js
+++ b/api/upwork-api.js
@@ -90,8 +90,21 @@ async function _executeGraphQLQuery(bearerToken, endpointAlias, query, variables
       return { error: true, status: response.status, body: responseBodyText.substring(0, 300) };
     }
 
-    const data = await response.json();
-    return data; // Return the full response for the caller to check for errors and destructure
+    // --- Start of Recommended Change ---
+    const responseBodyText = await response.text();
+    try {
+      const data = JSON.parse(responseBodyText);
+      return data; // Return the parsed data
+    } catch (parsingError) {
+      console.error(
+        `API (_executeGraphQLQuery): Failed to parse JSON response for alias ${endpointAlias}.`,
+        parsingError
+      );
+      // Log the start of the response that failed to help debug what was received
+      console.warn(`Response text that failed parsing: ${responseBodyText.substring(0, 500)}`);
+      return { error: true, type: 'parsing', message: parsingError.message };
+    }
+    // --- End of Recommended Change ---
   } catch (error) {
     console.error(
       `API (_executeGraphQLQuery): Network error for alias ${endpointAlias} with token ${bearerToken.substring(0, 10)}...:`,


### PR DESCRIPTION
**Closes #7**

### Description
This PR hardens the `_executeGraphQLQuery` helper function to prevent crashes when the API returns a `200 OK` response with a non-JSON body (e.g., an HTML error page or maintenance message).

This makes the extension's API layer more robust and resilient to unexpected server responses.

### Changes Implemented
*   The helper function now reads the response body as text first using `response.text()`.
*   A `try...catch` block is used to safely parse the text with `JSON.parse()`.
*   If parsing fails, a specific `{ error: true, type: 'parsing', ... }` object is returned.
*   The error log now includes the first 500 characters of the invalid response body to significantly improve debugging.