### PR TITLE
Fix: Resolve ESLint OOM Error in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.map
 *.d.ts
 tsconfig.tsbuildinfo
+.eslintcache

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,16 @@ import tseslint from 'typescript-eslint';
 export default tseslint.config(
   // 1. Global ignore patterns
   {
-    ignores: ['node_modules/', 'lib/', 'llm_context/', 'dist/', 'api/'],
+    ignores: [
+      'node_modules/',
+      'dist/',
+      'docs/',
+      '.github/',
+      '.claude/',
+      'llm_context/',
+      'lib/',
+      'api/', // This likely has no effect but is kept for safety
+    ],
   },
 
   // 2. Base configurations (apply to all linted files)

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lib": "lib"
   },
   "scripts": {
-    "lint": "eslint . --ext .js,.ts",
-    "lint:fix": "eslint . --ext .js,.ts --fix",
+    "lint": "eslint . --ext .js,.ts --cache",
+    "lint:fix": "eslint . --ext .js,.ts --fix --cache",
     "format": "prettier --write \"**/*.{js,ts,json,html,css,md}\"",
     "type-check": "tsc --noEmit",
     "test": "jest",


### PR DESCRIPTION
This PR resolves the ESLint out-of-memory error that was causing CI failures.

- Updates \eslint.config.mjs\ to ignore non-source-code directories.
- Enables ESLint's \--cache\ flag for improved performance.

Fixes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded the list of directories ignored by linting to include additional folders.
  * Improved linting performance by enabling caching during lint runs.
  * Updated version control settings to exclude the ESLint cache file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->