### PR TITLE
Chore: Add Codacy analysis GitHub Action

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,0 +1,21 @@
+name: Codacy Analysis
+
+on:
+  push:
+    branches: [main, typescript]
+  pull_request:
+    branches: [main, typescript]
+
+jobs:
+  codacy-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Codacy Analysis
+        uses: codacy/codacy-analysis-cli-action@master
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          verbose: true
+          output: results.sarif
+          format: sarif
+          gh-code-scanning-compat: true


### PR DESCRIPTION
Closes #43.

This PR integrates Codacy analysis directly into our GitHub Actions workflow to automate code quality checks on every push and pull request.

This requires the CODACY_PROJECT_TOKEN to be set in the repository's Actions secrets, which has already been done.